### PR TITLE
[Minor change] Explicity mention the git repo's full clone url

### DIFF
--- a/config-server/README.adoc
+++ b/config-server/README.adoc
@@ -16,7 +16,7 @@ $ docker run --publish 8888:8888 steeltoeoss/config-server
 .Custom Git Repo Configuration
 ----
 $ docker run --publish 8888:8888 steeltoeoss/config-server \
-    --spring.cloud.config.server.git.uri=https://github.com/myorg/myrepo
+    --spring.cloud.config.server.git.uri=https://github.com/myorg/myrepo.git
 ----
 
 .Local File System Configuration


### PR DESCRIPTION
If the `.git` suffix is left out of the `--spring.cloud.config.server.git.uri` param, then you'll likely encounter the below error while using the config server. 

![image](https://user-images.githubusercontent.com/2327905/172631790-2d40b464-20ef-484b-9dae-02572068e469.png)

So ensuring that the docs properly reflect the fact that the git repo's full clone url (including the `.git` prefix) must be mentioned.